### PR TITLE
Make calls using `POST` instead of `GET`

### DIFF
--- a/authorize/apis/transaction.py
+++ b/authorize/apis/transaction.py
@@ -23,6 +23,7 @@ RESPONSE_FIELDS = {
 
 DEFAULT_CHARSET = 'iso-8859-1'
 
+
 def get_content_charset(resource):
     """Gets the charset encoding used in the given urlopen response."""
     if PY2:
@@ -33,6 +34,7 @@ def get_content_charset(resource):
     else:
         return resource.headers.get_content_charset(failobj=DEFAULT_CHARSET)
 
+
 def parse_response(response):
     response = response.split(';')
     fields = {}
@@ -40,15 +42,17 @@ def parse_response(response):
         fields[name] = response[index]
     return fields
 
+
 def safe_unicode_to_str(string):
     try:
         return str(string)
     except UnicodeEncodeError:
         return string.encode('utf-8')
 
+
 def convert_params_to_byte_str(params):
     converted_params = {}
-    for key,value in params.items():
+    for key, value in params.items():
         if isinstance(key, text_type):
             key = safe_unicode_to_str(key)
         if isinstance(value, text_type):
@@ -72,17 +76,19 @@ class TransactionAPI(object):
     def _make_call(self, params):
         params = convert_params_to_byte_str(params)
         params = urlencode(params)
-        url = '{0}?{1}'.format(self.url, params)
         try:
-            resource = urlopen(url)
+            resource = urlopen(self.url, data=params)
             response = resource.read().decode(
                 get_content_charset(resource) or DEFAULT_CHARSET)
         except IOError as e:
             raise AuthorizeConnectionError(e)
         fields = parse_response(response)
         if fields['response_code'] != '1':
-            e = AuthorizeResponseError('%s full_response=%r' %
-                (fields['response_reason_text'], fields))
+            e = AuthorizeResponseError(
+                '{0} full_response={1!r}'.format(
+                    fields['response_reason_text'], fields
+                )
+            )
             e.full_response = fields
             raise e
         return fields

--- a/authorize/apis/transaction.py
+++ b/authorize/apis/transaction.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from six import PY2, text_type
+from six import PY2, b, text_type
 from six.moves.urllib.parse import urlencode
 from six.moves.urllib.request import urlopen
 
@@ -77,7 +77,7 @@ class TransactionAPI(object):
         params = convert_params_to_byte_str(params)
         params = urlencode(params)
         try:
-            resource = urlopen(self.url, data=params)
+            resource = urlopen(self.url, data=b(params))
             response = resource.read().decode(
                 get_content_charset(resource) or DEFAULT_CHARSET)
         except IOError as e:

--- a/tests/test_api_transaction.py
+++ b/tests/test_api_transaction.py
@@ -10,11 +10,13 @@ from authorize.data import Address, CreditCard
 from authorize.exceptions import AuthorizeConnectionError, \
     AuthorizeResponseError
 
+
 class MockResponse(BytesIO):
     class Headers(dict):
         def getparam(self, *args, **kwargs):
             """Python 2 version"""
             return None
+
         def get_content_charset(self, failobj=None, *args, **kwargs):
             """Python 3 version"""
             return failobj
@@ -56,10 +58,11 @@ PARSED_ERROR = {
     'transaction_id': '2171062816',
 }
 
+
 class URL(object):
     """
     a class to enable comparing of two urls regardless of order of parameters
-    see http://stackoverflow.com/questions/5371992/comparing-two-urls-in-python 
+    see http://stackoverflow.com/questions/5371992/comparing-two-urls-in-python
     """
     def __init__(self, url):
         parts = urlparse(url)
@@ -73,6 +76,7 @@ class URL(object):
 
     def __hash__(self, other):
         return hash(self.parts)
+
 
 class TransactionAPITests(TestCase):
     def setUp(self):
@@ -93,23 +97,30 @@ class TransactionAPITests(TestCase):
     def test_make_call(self, urlopen):
         urlopen.side_effect = self.success
         result = self.api._make_call({'a': '1', 'b': '2'})
-        self.assertEqual(URL(urlopen.call_args[0][0]),
-            URL('{0}?a=1&b=2'.format(TEST_URL)))
+        self.assertEqual(
+            URL("{0}?{1}".format(
+                urlopen.call_args[0][0], urlopen.call_args[1]['data']
+            )),
+            URL('{0}?a=1&b=2'.format(TEST_URL))
+        )
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
     def test_make_call_with_unicode(self, urlopen):
         urlopen.side_effect = self.success
         result = self.api._make_call({u('\xe3'): '1', 'b': u('\xe3')})
-        self.assertEqual(URL(urlopen.call_args[0][0]),
-            URL('{0}?%C3%A3=1&b=%C3%A3'.format(TEST_URL)))
+        self.assertEqual(
+            URL("{0}?{1}".format(
+                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
+            URL('{0}?%C3%A3=1&b=%C3%A3'.format(TEST_URL))
+        )
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
     def test_make_call_connection_error(self, urlopen):
         urlopen.side_effect = IOError('Borked')
         self.assertRaises(AuthorizeConnectionError, self.api._make_call,
-            {'a': '1', 'b': '2'})
+                          {'a': '1', 'b': '2'})
 
     @mock.patch('authorize.apis.transaction.urlopen')
     def test_make_call_response_error(self, urlopen):
@@ -117,7 +128,9 @@ class TransactionAPITests(TestCase):
         try:
             self.api._make_call({'a': '1', 'b': '2'})
         except AuthorizeResponseError as e:
-            self.assertTrue(str(e).startswith('This transaction has been declined.'))
+            self.assertTrue(str(e).startswith(
+                'This transaction has been declined.'
+            ))
             self.assertEqual(e.full_response, PARSED_ERROR)
 
     def test_add_params(self):
@@ -136,8 +149,9 @@ class TransactionAPITests(TestCase):
             'x_zip': '90291',
             'x_country': 'US',
         })
-        params = self.api._add_params({},
-            credit_card=self.credit_card, address=self.address)
+        params = self.api._add_params(
+            {}, credit_card=self.credit_card, address=self.address
+        )
         self.assertEqual(params, {
             'x_card_num': '4111111111111111',
             'x_exp_date': '01-{0}'.format(self.year),
@@ -153,26 +167,34 @@ class TransactionAPITests(TestCase):
     def test_auth(self, urlopen):
         urlopen.side_effect = self.success
         result = self.api.auth(20, self.credit_card, self.address)
-        self.assertEqual(URL(urlopen.call_args[0][0]),
+        self.assertEqual(
+            URL("{0}?{1}".format(
+                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
             URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-            '&x_zip=90291&x_card_num=4111111111111111&x_amount=20.00'
-            '&x_tran_key=456&x_city=Venice&x_country=US&x_version=3.1'
-            '&x_state=CA&x_delim_char=%3B&x_address=45+Rose+Ave'
-            '&x_exp_date=01-{0}&x_test_request=FALSE&x_card_code=911'
-            '&x_type=AUTH_ONLY&x_delim_data=TRUE'.format(str(self.year))))
+                '&x_zip=90291&x_card_num=4111111111111111&x_amount=20.00'
+                '&x_tran_key=456&x_city=Venice&x_country=US&x_version=3.1'
+                '&x_state=CA&x_delim_char=%3B&x_address=45+Rose+Ave'
+                '&x_exp_date=01-{0}&x_test_request=FALSE&x_card_code=911'
+                '&x_type=AUTH_ONLY&x_delim_data=TRUE'.format(str(self.year)))
+        )
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
     def test_capture(self, urlopen):
         urlopen.side_effect = self.success
         result = self.api.capture(20, self.credit_card, self.address)
-        self.assertEqual(URL(urlopen.call_args[0][0]),
+        self.assertEqual(
+            URL("{0}?{1}".format(
+                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
             URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-            '&x_zip=90291&x_card_num=4111111111111111&x_amount=20.00'
-            '&x_tran_key=456&x_city=Venice&x_country=US&x_version=3.1'
-            '&x_state=CA&x_delim_char=%3B&x_address=45+Rose+Ave'
-            '&x_exp_date=01-{0}&x_test_request=FALSE&x_card_code=911'
-            '&x_type=AUTH_CAPTURE&x_delim_data=TRUE'.format(str(self.year))))
+                '&x_zip=90291&x_card_num=4111111111111111&x_amount=20.00'
+                '&x_tran_key=456&x_city=Venice&x_country=US&x_version=3.1'
+                '&x_state=CA&x_delim_char=%3B&x_address=45+Rose+Ave'
+                '&x_exp_date=01-{0}&x_test_request=FALSE&x_card_code=911'
+                '&x_type=AUTH_CAPTURE&x_delim_data=TRUE'.format(
+                    str(self.year))
+                )
+        )
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
@@ -181,20 +203,25 @@ class TransactionAPITests(TestCase):
 
         # Test without specified amount
         result = self.api.settle('123456')
-        self.assertEqual(URL(urlopen.call_args[0][0]),
+        self.assertEqual(
+            URL("{0}?{1}".format(
+                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
             URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-            '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B'
-            '&x_type=PRIOR_AUTH_CAPTURE&x_delim_data=TRUE&x_tran_key=456'
-            '&x_test_request=FALSE'))
+                '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B'
+                '&x_type=PRIOR_AUTH_CAPTURE&x_delim_data=TRUE&x_tran_key=456'
+                '&x_test_request=FALSE')
+        )
         self.assertEqual(result, PARSED_SUCCESS)
 
         # Test with specified amount
         result = self.api.settle('123456', amount=10)
-        self.assertEqual(URL(urlopen.call_args[0][0]),
+        self.assertEqual(
+            URL("{0}?{1}".format(
+                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
             URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-            '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B'
-            '&x_type=PRIOR_AUTH_CAPTURE&x_amount=10.00&x_delim_data=TRUE'
-            '&x_tran_key=456&x_test_request=FALSE'))
+                '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B'
+                '&x_type=PRIOR_AUTH_CAPTURE&x_amount=10.00&x_delim_data=TRUE'
+                '&x_tran_key=456&x_test_request=FALSE'))
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
@@ -203,19 +230,24 @@ class TransactionAPITests(TestCase):
 
         # Test with transaction_id, amount
         result = self.api.credit('1111', '123456', 10)
-        self.assertEqual(URL(urlopen.call_args[0][0]),
+        self.assertEqual(
+            URL("{0}?{1}".format(
+                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
             URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-            '&x_trans_id=123456&x_version=3.1&x_amount=10.00&x_delim_char=%3B'
-            '&x_type=CREDIT&x_card_num=1111&x_delim_data=TRUE&x_tran_key=456'
-            '&x_test_request=FALSE'))
+                '&x_trans_id=123456&x_version=3.1&x_amount=10.00'
+                '&x_delim_char=%3B&x_type=CREDIT&x_card_num=1111'
+                '&x_delim_data=TRUE&x_tran_key=456&x_test_request=FALSE')
+        )
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
     def test_void(self, urlopen):
         urlopen.side_effect = self.success
         result = self.api.void('123456')
-        self.assertEqual(URL(urlopen.call_args[0][0]),
+        self.assertEqual(
+            URL("{0}?{1}".format(
+                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
             URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-            '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B&x_type=VOID'
-            '&x_delim_data=TRUE&x_tran_key=456&x_test_request=FALSE'))
+                '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B&x_type=VOID'
+                '&x_delim_data=TRUE&x_tran_key=456&x_test_request=FALSE'))
         self.assertEqual(result, PARSED_SUCCESS)

--- a/tests/test_api_transaction.py
+++ b/tests/test_api_transaction.py
@@ -1,9 +1,9 @@
-from six import BytesIO, u
+from six import BytesIO, binary_type, text_type, u
 from datetime import date
 
 import mock
 from unittest2 import TestCase
-from six.moves.urllib.parse import urlparse, parse_qsl, unquote_plus
+from six.moves.urllib.parse import parse_qsl, urlencode
 
 from authorize.apis.transaction import PROD_URL, TEST_URL, TransactionAPI
 from authorize.data import Address, CreditCard
@@ -59,23 +59,16 @@ PARSED_ERROR = {
 }
 
 
-class URL(object):
-    """
-    a class to enable comparing of two urls regardless of order of parameters
-    see http://stackoverflow.com/questions/5371992/comparing-two-urls-in-python
-    """
-    def __init__(self, url):
-        parts = urlparse(url)
-        _query = frozenset(parse_qsl(parts.query))
-        _path = unquote_plus(parts.path)
-        parts = parts._replace(query=_query, path=_path)
-        self.parts = parts
+def _unicode_str(s):
+    if isinstance(s, text_type):
+        return s
+    if isinstance(s, binary_type):
+        return s.decode('utf-8')
 
-    def __eq__(self, other):
-        return self.parts == other.parts
 
-    def __hash__(self, other):
-        return hash(self.parts)
+def _are_params_eq(params1, params2):
+    _params1, _params2 = map(_unicode_str, (params1, params2))
+    return frozenset(parse_qsl(_params1)) == frozenset(parse_qsl(_params2))
 
 
 class TransactionAPITests(TestCase):
@@ -96,24 +89,22 @@ class TransactionAPITests(TestCase):
     @mock.patch('authorize.apis.transaction.urlopen')
     def test_make_call(self, urlopen):
         urlopen.side_effect = self.success
-        result = self.api._make_call({'a': '1', 'b': '2'})
-        self.assertEqual(
-            URL("{0}?{1}".format(
-                urlopen.call_args[0][0], urlopen.call_args[1]['data']
-            )),
-            URL('{0}?a=1&b=2'.format(TEST_URL))
-        )
+        params = {'a': '1', 'b': '2'}
+        result = self.api._make_call(params)
+        self.assertEqual(urlopen.call_args[0][0], TEST_URL)
+        self.assertTrue(_are_params_eq(
+            urlopen.call_args[1]['data'], urlencode(params)
+        ))
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
     def test_make_call_with_unicode(self, urlopen):
         urlopen.side_effect = self.success
         result = self.api._make_call({u('\xe3'): '1', 'b': u('\xe3')})
-        self.assertEqual(
-            URL("{0}?{1}".format(
-                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
-            URL('{0}?%C3%A3=1&b=%C3%A3'.format(TEST_URL))
-        )
+        self.assertEqual(urlopen.call_args[0][0], TEST_URL)
+        self.assertTrue(_are_params_eq(
+            urlopen.call_args[1]['data'], 'b=%C3%A3&%C3%A3=1'
+        ))
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
@@ -167,34 +158,32 @@ class TransactionAPITests(TestCase):
     def test_auth(self, urlopen):
         urlopen.side_effect = self.success
         result = self.api.auth(20, self.credit_card, self.address)
-        self.assertEqual(
-            URL("{0}?{1}".format(
-                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
-            URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-                '&x_zip=90291&x_card_num=4111111111111111&x_amount=20.00'
-                '&x_tran_key=456&x_city=Venice&x_country=US&x_version=3.1'
-                '&x_state=CA&x_delim_char=%3B&x_address=45+Rose+Ave'
-                '&x_exp_date=01-{0}&x_test_request=FALSE&x_card_code=911'
-                '&x_type=AUTH_ONLY&x_delim_data=TRUE'.format(str(self.year)))
-        )
+        self.assertEqual(urlopen.call_args[0][0], TEST_URL)
+        self.assertTrue(urlopen.call_args[1]['data'], (
+            'x_login=123&x_zip=90291&x_card_num=4111111111111111&'
+            'x_amount=20.00&x_tran_key=456&x_city=Venice&x_country=US&'
+            'x_version=3.1&x_state=CA&x_delim_char=%3B&'
+            'x_address=45+Rose+Ave&x_exp_date=01-{0}&x_test_request=FALSE'
+            '&x_card_code=911&x_type=AUTH_ONLY&x_delim_data=TRUE'.format(
+                str(self.year)
+            )
+        ))
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
     def test_capture(self, urlopen):
         urlopen.side_effect = self.success
         result = self.api.capture(20, self.credit_card, self.address)
-        self.assertEqual(
-            URL("{0}?{1}".format(
-                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
-            URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-                '&x_zip=90291&x_card_num=4111111111111111&x_amount=20.00'
-                '&x_tran_key=456&x_city=Venice&x_country=US&x_version=3.1'
-                '&x_state=CA&x_delim_char=%3B&x_address=45+Rose+Ave'
-                '&x_exp_date=01-{0}&x_test_request=FALSE&x_card_code=911'
-                '&x_type=AUTH_CAPTURE&x_delim_data=TRUE'.format(
-                    str(self.year))
-                )
-        )
+        self.assertEqual(urlopen.call_args[0][0], TEST_URL)
+        self.assertTrue(urlopen.call_args[1]['data'], (
+            'x_login=123&x_zip=90291&x_card_num=4111111111111111&'
+            'x_amount=20.00&x_tran_key=456&x_city=Venice&x_country=US&'
+            'x_version=3.1&x_state=CA&x_delim_char=%3B&'
+            'x_address=45+Rose+Ave&x_exp_date=01-{0}&x_test_request=FALSE'
+            '&x_card_code=911&x_type=AUTH_ONLY&x_delim_data=TRUE'.format(
+                str(self.year)
+            )
+        ))
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
@@ -203,25 +192,24 @@ class TransactionAPITests(TestCase):
 
         # Test without specified amount
         result = self.api.settle('123456')
-        self.assertEqual(
-            URL("{0}?{1}".format(
-                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
-            URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-                '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B'
-                '&x_type=PRIOR_AUTH_CAPTURE&x_delim_data=TRUE&x_tran_key=456'
-                '&x_test_request=FALSE')
-        )
+        self.assertEqual(urlopen.call_args[0][0], TEST_URL)
+        self.assertTrue(urlopen.call_args[1]['data'], (
+            'https://test.authorize.net/gateway/transact.dll?x_login=123'
+            '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B'
+            '&x_type=PRIOR_AUTH_CAPTURE&x_delim_data=TRUE&x_tran_key=456'
+            '&x_test_request=FALSE'
+        ))
         self.assertEqual(result, PARSED_SUCCESS)
 
         # Test with specified amount
         result = self.api.settle('123456', amount=10)
-        self.assertEqual(
-            URL("{0}?{1}".format(
-                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
-            URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-                '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B'
-                '&x_type=PRIOR_AUTH_CAPTURE&x_amount=10.00&x_delim_data=TRUE'
-                '&x_tran_key=456&x_test_request=FALSE'))
+        self.assertEqual(urlopen.call_args[0][0], TEST_URL)
+        self.assertTrue(urlopen.call_args[1]['data'], (
+            'https://test.authorize.net/gateway/transact.dll?x_login=123'
+            '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B'
+            '&x_type=PRIOR_AUTH_CAPTURE&x_amount=10.00&x_delim_data=TRUE'
+            '&x_tran_key=456&x_test_request=FALSE'
+        ))
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
@@ -230,24 +218,23 @@ class TransactionAPITests(TestCase):
 
         # Test with transaction_id, amount
         result = self.api.credit('1111', '123456', 10)
-        self.assertEqual(
-            URL("{0}?{1}".format(
-                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
-            URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-                '&x_trans_id=123456&x_version=3.1&x_amount=10.00'
-                '&x_delim_char=%3B&x_type=CREDIT&x_card_num=1111'
-                '&x_delim_data=TRUE&x_tran_key=456&x_test_request=FALSE')
-        )
+        self.assertEqual(urlopen.call_args[0][0], TEST_URL)
+        self.assertTrue(urlopen.call_args[1]['data'], (
+            'https://test.authorize.net/gateway/transact.dll?x_login=123'
+            '&x_trans_id=123456&x_version=3.1&x_amount=10.00'
+            '&x_delim_char=%3B&x_type=CREDIT&x_card_num=1111'
+            '&x_delim_data=TRUE&x_tran_key=456&x_test_request=FALSE'
+        ))
         self.assertEqual(result, PARSED_SUCCESS)
 
     @mock.patch('authorize.apis.transaction.urlopen')
     def test_void(self, urlopen):
         urlopen.side_effect = self.success
         result = self.api.void('123456')
-        self.assertEqual(
-            URL("{0}?{1}".format(
-                urlopen.call_args[0][0], urlopen.call_args[1]['data'])),
-            URL('https://test.authorize.net/gateway/transact.dll?x_login=123'
-                '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B&x_type=VOID'
-                '&x_delim_data=TRUE&x_tran_key=456&x_test_request=FALSE'))
+        self.assertEqual(urlopen.call_args[0][0], TEST_URL)
+        self.assertTrue(urlopen.call_args[1]['data'], (
+            'https://test.authorize.net/gateway/transact.dll?x_login=123'
+            '&x_trans_id=123456&x_version=3.1&x_delim_char=%3B&x_type=VOID'
+            '&x_delim_data=TRUE&x_tran_key=456&x_test_request=FALSE'
+        ))
         self.assertEqual(result, PARSED_SUCCESS)


### PR DESCRIPTION
Per Authorize.Net:

> Because HTTP GET methods do not adhere to current TLS protection requirements,
> Authorize.Net will not allow HTTP GET methods for transaction requests as of June 30, 2016.
> We recommend that you immediately update your code to use the HTTP POST method instead.

> Any transaction request submitted using HTTP GET after June 30th will be rejected.